### PR TITLE
Add code-server iframe on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Proyecto base de Django preparado para producción usando Docker Compose y Nginx
 docker compose up --build
 ```
 
-El acceso a `http://localhost` mostrará la aplicación Django. Solo los usuarios
-registrados podrán acceder a la ruta `/code-server/`, que muestra una instancia
-de [code-server](https://github.com/coder/code-server) dentro de un iframe.
+El acceso a `http://localhost` mostrará la aplicación Django.
+Tras iniciar sesión, la página de inicio incluye un iframe con
+una instancia de [code-server](https://github.com/coder/code-server).

--- a/mysite/templates/home.html
+++ b/mysite/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Welcome {{ user.username }}</h1>
+<iframe src="/code-server/" width="100%" height="800" style="border: none;"></iframe>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed code-server iframe on home page
- update README to explain that the home page shows code-server

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_688c50c4e6788323ad7539a3a187bfa9